### PR TITLE
Fix capitalization of filename in #include directive

### DIFF
--- a/src/Freenove_WS2812B_RGBLED_Controller.h
+++ b/src/Freenove_WS2812B_RGBLED_Controller.h
@@ -11,7 +11,7 @@
 #define _FREENOVE_WS2812B_RGBLED_CONTROLLER_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.